### PR TITLE
Collaborators url fixed to work with production URLs because Restangu…

### DIFF
--- a/src/app/matrix/collaborators-matrix.controller.js
+++ b/src/app/matrix/collaborators-matrix.controller.js
@@ -2,7 +2,7 @@
 
 angular.module('microInfraView')
   .controller('CollaboratorsMatrixCtrl', function ($scope, $log, Restangular) {
-    Restangular.one('all').get().then(function (collaborators) {
+    Restangular.all('collaborators').one('all').get().then(function (collaborators) {
       $scope.current = {collaborator: {}};
 
       $scope.allCollaborators = collaborators.plain();


### PR DESCRIPTION
…lar starts from root instead of relative path - the same for a second time because of forgotten matrix controller
